### PR TITLE
Add postgresql client.

### DIFF
--- a/task/scripts/build.sh
+++ b/task/scripts/build.sh
@@ -19,6 +19,7 @@ apt-get -y install build-essential \
                    curl \
                    git \
                    openssl \
+                   postgresql-client \
                    postgresql-client-common \
                    python3-pip \
                    ruby2.0 \


### PR DESCRIPTION
Just using `postgresql-client-common`, we get `You must install at least one postgresql-client-<version> package.` on running `psql`. 