### PR TITLE
Add an alias for boshv2 to bosh-cli and boshv1 to bosh-legacy

### DIFF
--- a/task/scripts/build.sh
+++ b/task/scripts/build.sh
@@ -90,6 +90,7 @@ gem install cf-uaac -v "$UAAC_CLI_RELEASE_VERSION" --no-ri --no-rdoc
 echo "13. Installing BOSH CLI v2"
 curl -L -o /usr/local/bin/bosh-cli "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH_CLI_V2_RELEASE_VERSION}-linux-amd64"
 chmod +x /usr/local/bin/bosh-cli
+alias gosh=/usr/local/bin/bosh-cli
 
 echo "14. Installing RiemannC"
 git clone https://github.com/dhilst/riemann-c-client /tmp/riemann-c-client && pushd /tmp/riemann-c-client && ./build.sh && ./configure --prefix=/usr && make install && popd && rm -fr /tmp/riemann-c-client

--- a/task/scripts/build.sh
+++ b/task/scripts/build.sh
@@ -68,6 +68,7 @@ chmod +x /usr/local/bin/bosh-init
 
 echo "7. Installing BOSH CLI"
 gem install bosh_cli -v "$BOSH_CLI_RELEASE_VERSION" --no-ri --no-rdoc
+mv /usr/local/bin/bosh /usr/local/bin/bosh-legacy
 
 echo "8. Installing jq"
 curl -L -o /usr/local/bin/jq "https://github.com/stedolan/jq/releases/download/jq-$JQ_RELEASE_VERSION/jq-linux64"
@@ -88,9 +89,9 @@ echo "12. Installing uaac"
 gem install cf-uaac -v "$UAAC_CLI_RELEASE_VERSION" --no-ri --no-rdoc
 
 echo "13. Installing BOSH CLI v2"
-curl -L -o /usr/local/bin/bosh-cli "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH_CLI_V2_RELEASE_VERSION}-linux-amd64"
-chmod +x /usr/local/bin/bosh-cli
-alias gosh=/usr/local/bin/bosh-cli
+curl -L -o /usr/local/bin/bosh "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH_CLI_V2_RELEASE_VERSION}-linux-amd64"
+chmod +x /usr/local/bin/bosh
+alias bosh-cli=$(which bosh)
 
 echo "14. Installing RiemannC"
 git clone https://github.com/dhilst/riemann-c-client /tmp/riemann-c-client && pushd /tmp/riemann-c-client && ./build.sh && ./configure --prefix=/usr && make install && popd && rm -fr /tmp/riemann-c-client


### PR DESCRIPTION
When installing the new Golang Bosh CLI v2 locally, I found that it was being installed as `gosh` instead of `bosh-cli` or something similar. I also tend to run `alias gosh=$(which bosh-cli)` in almost every jumpbox I create. I don't want to completely modify the name of the executable, but having an alias is great so I can save on typing 27 characters every time I shell in.

Feel free to close this if it's a big deal, I'll simply go back to typing. :joy: