### PR TITLE
adding doomsday for certificates.

### DIFF
--- a/task/concourse-tasks/scripts/build.sh
+++ b/task/concourse-tasks/scripts/build.sh
@@ -148,3 +148,7 @@ pushd /tmp/bats-repo
 ./install.sh /usr/local
 popd
 rm -rf /tmp/bats-repo
+
+echo "Installing Doomsday CLI"
+wget https://github.com/doomsday-project/doomsday/releases/latest/download/doomsday-linux
+mv ./doomsday-linux /usr/bin/doomsday


### PR DESCRIPTION
Just adding the CLI so we don't have to keep downloading it.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>