### PR TITLE
remove uaa cli

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -225,11 +225,6 @@ wget -q https://github.com/cloud-gov/cg-doomsday/releases/latest/download/doomsd
 chmod a+x doomsday-linux-amd64
 mv ./doomsday-linux-amd64 /usr/bin/doomsday
 
-echo "Installing new UAA client."
-wget -q https://github.com/cloudfoundry/uaa-cli/releases/download/${UAA_CLIENT_VERSION}/uaa-linux-amd64-${UAA_CLIENT_VERSION}
-mv uaa-linux-amd64-${UAA_CLIENT_VERSION} /usr/bin/uaa
-chmod a+x /usr/bin/uaa
-
 echo "Installing GitHub CLI"
 # # Instructions adapted from: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes the uaa client because it hasn't gotten a new release since November 1, 2024

## security considerations
We already include the `uaac` command provided by the ruby gem, so removing this shouldn't cause an issue but will improve our security posture.
